### PR TITLE
CI in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - run: npm ci
+      - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,0 @@
-language: node_js
-node_js: 8.3

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
---compilers js:babel-core/register
+--require babel-core/register
 --recursive


### PR DESCRIPTION
TravisCI seems to no longer work for this repo and most of the world has moved on to GitHub Actions so proposing to move this repo to GitHub Actions too.

Also fixes `npm test` which seems to have been hit by a [deprecation in mocha](https://github.com/mochajs/mocha/wiki/compilers-deprecation)