### PR TITLE
Add commit counter to dashboard

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,6 +37,7 @@ app.get('/challenge/question/:team', challenge.question);
 app.post('/challenge/answer/:team', challenge.answer);
 
 app.put('/teams/:team', branch.add);
+app.post('/teams/:team/commits', branch.addCommits);
 app.delete('/teams/:team', branch.remove);
 
 require('./routes/connection').init()

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,3 +9,14 @@ a {
 
 .leftPane      { width: 50%; float: left; }
 .rightPane { width: 50%; float: right; }
+
+.info {
+  position: relative;
+}
+
+.commit-number {
+  position: absolute;
+  top: 20%;
+  left: 35%;
+  color: white;
+}

--- a/assets/js/details.js
+++ b/assets/js/details.js
@@ -28,14 +28,24 @@ $(function() {
     return results;
   };
   addTeam = function(item) {
-    var i, j, ref, row;
+    var i, j, ref, row, commitNumberText;
     row = $("<tr id='team-" + item.name + "'>");
     row.append("<td>" + item.name + "</td>");
     for (i = j = 0, ref = currentRound; 0 <= ref ? j <= ref : j >= ref; i = 0 <= ref ? ++j : --j) {
       if (!item[i]) {
         item[i] = 'failure';
       }
-      row.append("<td id='info-" + item.name + "-" + i + "'><img id='status-" + item.name + "-" + i + "' src='/assets/" + item[i] + ".png' height='25' width='25' /></td>");
+      if (item.commits && item.commits[i] > 0) {
+        commitNumberText = item.commits[i]
+      } else {
+        commitNumberText = ""
+      }
+      itemHtml = ""
+      itemHtml += "<td class='info' id='info-" + item.name + "-" + i + "'>";
+      itemHtml += "  <img id='status-" + item.name + "-" + i + "' src='/assets/" + item[i] + ".png' height='25' width='25'/>";
+      itemHtml += "<div class='commit-number'>"+commitNumberText+"</div>"; // TODO update this on websocket
+      itemHtml += "</td>";
+      row.append(itemHtml)
     }
     return table.append(row);
   };
@@ -86,6 +96,11 @@ $(function() {
       teams.splice(index, 1);
     }
     return $("#team-" + teamName).remove();
+  });
+
+  teamSocket.on('commits updated', function (data) {
+    debugger
+    $("#info-" + data.team + "-" + data.round+" .commit-number").text(data.numberOfCommits)
   });
   challengeSocket = io.connect('/challenge');
   challengeSocket.on('result', function(data) {

--- a/docker/git-simple-http/git-hooks/post-receive
+++ b/docker/git-simple-http/git-hooks/post-receive
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+while read oldrev newrev ref
+do
+  if [ "${oldrev}" == "0000000000000000000000000000000000000000" ]; then
+    echo "Created new team, don't neeed new commits here"
+    exit 0
+  fi
+
+  if [ "$refname" != "refs/heads/master" ] && [[ "$ref" =~ ^refs/heads/([a-zA-Z0-9_-]+)$ ]]; then
+    count=$(git rev-list --count ${oldrev}..${newrev})
+    team="${BASH_REMATCH[1]}"
+    echo "*** Team ${team} pushed ${count} commits"
+    wget --method=POST -bqO- "http://whisper:3000/teams/${team}/commits?added=${count}"
+  else
+    echo "Ignoring this branch for commit counting" >&2
+    exit 0
+  fi
+done
+


### PR DESCRIPTION
This PR adds a feature to count commits during a round for each team. 
During the last dry-run for a workshop, we frequently forgot to push our changes so adding this feature might allow facilitators can see which teams might have forgotten to push their changes before starting the next round. 

Looking something like this: 
<img width="165" alt="Screenshot 2022-11-06 at 16 58 20" src="https://user-images.githubusercontent.com/540525/200164733-78adbf50-7336-4007-ba63-419e53719927.png">

Obviously, not very fancy styling yet, more proof of concept - let me know what you think and we can see if we want to merge this